### PR TITLE
truncate big numbers to the maximum NUMERIC range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.2 (2020-07-16)
+-------------------
+
+- Truncate big numbers to the maximum range for NUMERIC in BigQuery
+- Fix an issue when loading table names with reserved keywords
+
 1.0.1 (2020-07-05)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
       long_description = f.read()
 
 setup(name="pipelinewise-target-bigquery",
-      version="1.0.1",
+      version="1.0.2",
       description="Singer.io target for loading data to BigQuery - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -7,7 +7,7 @@ import re
 import itertools
 import time
 import datetime
-from decimal import Decimal
+from decimal import Decimal, getcontext
 
 from google.cloud import bigquery
 from google.cloud.bigquery.job import SourceFormat
@@ -19,6 +19,12 @@ from google.api_core import exceptions
 
 logger = singer.get_logger()
 
+PRECISION = 38
+SCALE = 9
+getcontext().prec = PRECISION
+# Limit decimals to the same precision and scale as BigQuery accepts
+ALLOWED_DECIMALS = Decimal(10) ** Decimal(-SCALE)
+MAX_NUM = (Decimal(10) ** Decimal(PRECISION-SCALE)) - ALLOWED_DECIMALS
 
 def validate_config(config):
     errors = []
@@ -407,7 +413,6 @@ class DbSync:
     # TODO: write tests for the json.dumps lines below and verify nesting
     # TODO: improve performance
     def records_to_avro(self, records):
-        NINE_DECIMALS = Decimal('0.000000001')
         for record in records:
             flatten = flatten_record(record, max_level=self.data_flattening_max_level)
             result = {}
@@ -421,8 +426,12 @@ class DbSync:
                            or '$ref' in props['items'])):
                         result[name] = json.dumps(flatten[name])
                     elif 'number' in props['type']:
-                        n = flatten[name]
-                        result[name] = None if n is None else Decimal(n).quantize(NINE_DECIMALS)
+                        if flatten[name] is None:
+                            result[name] = None
+                        else:
+                            n = Decimal(flatten[name])
+                            # limit n to the range -MAX_NUM to MAX_NUM
+                            result[name] = MAX_NUM if n > MAX_NUM else -MAX_NUM if n < -MAX_NUM else n.quantize(ALLOWED_DECIMALS)
                     else:
                         result[name] = flatten[name] if name in flatten else ''
                 else:
@@ -492,8 +501,8 @@ class DbSync:
         table_without_schema = self.table_name(stream_schema_message['stream'], without_schema=True)
         temp_schema = self.connection_config.get('temp_schema', self.schema_name)
 
-        result = """MERGE {table}
-        USING {temp_schema}.{temp_table} s
+        result = """MERGE `{table}` t
+        USING `{temp_schema}`.`{temp_table}` s
         ON {primary_key_condition}
         WHEN MATCHED THEN
             UPDATE SET {set_values}
@@ -503,7 +512,7 @@ class DbSync:
             table=table,
             temp_schema=temp_schema,
             temp_table=temp_table,
-            primary_key_condition=self.primary_key_condition(table_without_schema),
+            primary_key_condition=self.primary_key_condition(),
             set_values=', '.join(
                 '{}=s.{}'.format(
                     safe_column_name(self.renamed_columns.get(c, c), quotes=True),
@@ -515,14 +524,13 @@ class DbSync:
             cols=', '.join(safe_column_name(c,quotes=True) for c in self.column_names()))
         return result
 
-    def primary_key_condition(self, right_table):
+    def primary_key_condition(self):
         stream_schema_message = self.stream_schema_message
         names = primary_column_names(stream_schema_message)
         return ' AND '.join(
-            ['s.{} = {}.{}'
+            ['s.{} = t.{}'
                  .format(
                      safe_column_name(self.renamed_columns.get(c, c), quotes=True),
-                     right_table,
                      safe_column_name(c, quotes=True))
              for c in names])
 

--- a/tests/integration/resources/messages-with-bad-decimals.json
+++ b/tests/integration/resources/messages-with-bad-decimals.json
@@ -1,0 +1,11 @@
+{"type": "STATE", "value": {"currently_syncing": "tap_mysql_test-test_table_bad_decimals"}}
+{"type": "SCHEMA", "stream": "tap_mysql_test-test_table_bad_decimals", "schema": {"properties": {"C_pk": {"inclusion": "automatic", "minimum": -2147483648, "maximum": 2147483647, "type": ["null", "integer"]}, "decimalColumn": {"exclusiveMaximum": true, "exclusiveMinimum": true, "maximum": 100000000000000000000000000000000000000000000000000000000000000, "minimum": -100000000000000000000000000000000000000000000000000000000000000, "type": ["null", "number"]}}, "type": "object"}, "key_properties": ["C_pk"]}
+{"type": "ACTIVATE_VERSION", "stream": "tap_mysql_test-test_table_bad_decimals", "version": 1}
+{"type": "RECORD", "stream": "tap_mysql_test-test_table_bad_decimals", "record": {"C_pk": 1, "decimalColumn": 100000000000000000000000000000000000000000000000000000000000000}, "version": 1, "time_extracted": "2019-01-31T15:51:50.215998Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_table_bad_decimals", "record": {"C_pk": 2, "decimalColumn": -100000000000000000000000000000000000000000000000000000000000000}, "version": 1, "time_extracted": "2019-01-31T15:51:50.215998Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_table_bad_decimals", "record": {"C_pk": 3, "decimalColumn": 3.14159265359}, "version": 1, "time_extracted": "2019-01-31T15:51:50.215998Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_table_bad_decimals", "record": {"C_pk": 4}, "version": 1, "time_extracted": "2019-01-31T15:51:50.215998Z"}
+{"type": "RECORD", "stream": "tap_mysql_test-test_table_bad_decimals", "record": {"C_pk": 5, "decimalColumn": 1.0000000100009}, "version": 1, "time_extracted": "2019-01-31T15:51:50.215998Z"}
+{"type": "STATE", "value": {"currently_syncing": "tap_mysql_test-test_table_bad_decimals", "bookmarks": {"tap_mysql_test-test_table_one": {"initial_full_table_complete": true}, "tap_mysql_test-test_table_two": {"initial_full_table_complete": true}}}}
+{"type": "ACTIVATE_VERSION", "stream": "tap_mysql_test-test_table_bad_decimals", "version": 1}
+{"type": "STATE", "value": {"currently_syncing": null, "bookmarks": {"tap_mysql_test-test_table_bad_decimals": {"initial_full_table_complete": true}}}}

--- a/tests/integration/resources/messages-with-reserved-table-name.json
+++ b/tests/integration/resources/messages-with-reserved-table-name.json
@@ -1,0 +1,7 @@
+{"type": "STATE", "value": {"currently_syncing": "tap_mysql_test-full"}}
+{"type": "SCHEMA", "stream": "tap_mysql_test-full", "schema": {"properties": {"C_pk": {"inclusion": "automatic", "minimum": -2147483648, "maximum": 2147483647, "type": ["null", "integer"]}, "camelcaseColumn": {"inclusion": "available", "maxLength": 16, "type": ["null", "string"]}, "minus-column": {"inclusion": "available", "maxLength": 16, "type": ["null", "string"]}}, "type": "object"}, "key_properties": ["C_pk"]}
+{"type": "ACTIVATE_VERSION", "stream": "tap_mysql_test-full", "version": 1}
+{"type": "RECORD", "stream": "tap_mysql_test-full", "record": {"C_pk": 1, "camelcaseColumn": "Dummy row 1", "minus-column": "Dummy row 1"}, "version": 1, "time_extracted": "2019-01-31T15:51:50.215998Z"}
+{"type": "STATE", "value": {"currently_syncing": "tap_mysql_test-full", "bookmarks": {"tap_mysql_test-test_table_one": {"initial_full_table_complete": true}, "tap_mysql_test-test_table_two": {"initial_full_table_complete": true}}}}
+{"type": "ACTIVATE_VERSION", "stream": "tap_mysql_test-full", "version": 1}
+{"type": "STATE", "value": {"currently_syncing": null, "bookmarks": {"tap_mysql_test-full": {"initial_full_table_complete": true}}}}


### PR DESCRIPTION
Hi!

Sending another pull request to fix the replication of numbers that are bigger than what BigQuery accepts.
Numbers less or bigger than the range -99999999999999999999999999999.999999999 to 99999999999999999999999999999.999999999 will be truncated to those numbers instead

Also a small fix for when you try to replicate a table with a reserved word name such as `full` which was detected during the end to end testing of the target bigquery in the main repo