### PR TITLE
Remove `inflection` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(name="pipelinewise-target-bigquery",
           'pipelinewise-singer-python==1.*',
           'google-cloud-bigquery>=2.20.0,<=2.32.0',
           'joblib==1.1.0',
-          'inflection==0.3.1',
           'fastavro>=0.22.8,<=1.4.9'
       ],
       extras_require={

--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -1,7 +1,6 @@
 import json
 import sys
 import singer
-import inflection
 import re
 import itertools
 import time
@@ -170,12 +169,16 @@ def is_unstructured_object(props):
     return 'object' in props['type'] and not props.get('properties')
 
 
+def camelize(string):
+    return re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), string)
+
+
 def flatten_key(k, parent_key, sep):
     full_key = parent_key + [k]
     inflected_key = full_key.copy()
     reducer_index = 0
     while len(sep.join(inflected_key)) >= 255 and reducer_index < len(inflected_key):
-        reduced_key = re.sub(r'[a-z]', '', inflection.camelize(inflected_key[reducer_index]))
+        reduced_key = re.sub(r'[a-z]', '', camelize(inflected_key[reducer_index]))
         inflected_key[reducer_index] = \
             (reduced_key if len(reduced_key) > 1 else inflected_key[reducer_index][0:3]).lower()
         reducer_index += 1


### PR DESCRIPTION
## Problem

It is excessive to add a dependency for the use of a single regex. 

## Proposed changes

Implement the simple regex and remove the unneeded dependency. 

## Types of changes

What types of changes does your code introduce to target-bigquery?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
