### PR TITLE
Add ACTIVATE_VERSION support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: venv pylint unit_test integration_test
+
 venv:
 	python3 -m venv venv ;\
 	. ./venv/bin/activate ;\

--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -614,6 +614,12 @@ class DbSync:
         logger.info("Deleting rows from '{}' table... {}".format(table, query))
         logger.info("DELETE {}".format(self.query(query).result().total_rows))
 
+    def activate_table_version(self, stream, version):
+        table = self.table_name(stream, False)
+        query = "DELETE FROM {} WHERE _sdc_table_version != {}".format(table, version)
+        logger.info("Removing rows from previous versions from '{}' table... {}".format(table, query))
+        logger.info("DELETE {}".format(self.query(query).result().total_rows))
+
     def create_schema_if_not_exists(self, table_columns_cache=None):
         schema_name = self.schema_name
         temp_schema = self.connection_config.get('temp_schema', self.schema_name)

--- a/target_bigquery/stream_utils.py
+++ b/target_bigquery/stream_utils.py
@@ -108,6 +108,7 @@ def add_metadata_values_to_record(record_message):
     extended_record['_sdc_extracted_at'] = parse_datetime(record_message['time_extracted'])
     extended_record['_sdc_batched_at'] = datetime.now()
     extended_record['_sdc_deleted_at'] = parse_datetime(record_message.get('record', {}).get('_sdc_deleted_at'))
+    extended_record['_sdc_table_version'] = record_message.get('version')
 
     return extended_record
 

--- a/tests/integration/test_target_bigquery.py
+++ b/tests/integration/test_target_bigquery.py
@@ -17,7 +17,8 @@ except ImportError:
 METADATA_COLUMNS = [
     '_sdc_extracted_at',
     '_sdc_batched_at',
-    '_sdc_deleted_at'
+    '_sdc_deleted_at',
+    '_sdc_table_version'
 ]
 
 


### PR DESCRIPTION
## Problem

Add support for the experimental Singer command ACTIVATE_VERSION that removes records from non-matching versions. Needed to support tables with hard deletes where log based replication isn't available. This command isn't documented anywhere that I can find, but it seems like a few taps and targets support it, best reference I've found is https://gitlab.com/meltano/meltano/-/issues/2508

## Proposed changes

Using _sdc_table_version, which is defined in the Stitch docs here: https://www.stitchdata.com/docs/replication/loading/system-tables-columns

## Types of changes

What types of changes does your code introduce to target-bigquery?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
