### PR TITLE
Fix nested keys

### DIFF
--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import singer
+from collections.abc import MutableMapping
 import re
 import itertools
 import time

--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -395,10 +395,11 @@ class DbSync:
         if len(self.stream_schema_message['key_properties']) == 0:
             return None
         flatten = flatten_record(record, max_level=self.data_flattening_max_level)
+        primary_keys = [safe_column_name(p, quotes=False) for p in self.stream_schema_message['key_properties']]
         try:
-            key_props = [str(flatten[p.lower()]) for p in self.stream_schema_message['key_properties']]
+            key_props = [str(flatten[p]) for p in primary_keys]
         except Exception as exc:
-            logger.info("Cannot find {} primary key(s) in record: {}".format(self.stream_schema_message['key_properties'], flatten))
+            logger.info("Cannot find {} primary key(s) in record: {}".format(primary_keys, flatten))
             raise exc
         return ','.join(key_props)
 

--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -230,7 +230,11 @@ def flatten_record(d, parent_key=[], sep='__', level=0, max_level=0):
         if isinstance(v, MutableMapping) and level < max_level:
             items.extend(flatten_record(v, parent_key + [k], sep=sep, level=level+1, max_level=max_level).items())
         else:
-            items.append((new_key, v if type(v) is list or type(v) is dict else v))
+            if type(v) is dict:
+                # Need to fix the keys of nested dicts, lowercase etc
+                items.append((new_key, flatten_record(v, level = 0, max_level=0)))
+            else:
+                items.append((new_key, v))
     return dict(items)
 
 

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -247,16 +247,18 @@ class TestDBSync(unittest.TestCase):
         # NO FLATTENING - Record with simple properties should be a plain dictionary
         self.assertEqual(flatten_record(not_nested_record), not_nested_record)
 
+        # Include some uppercase and hyphens in nested keys to test that flatten_record
+        # fixes the key names recursively in all dicts to match schema
         nested_record = {
             "c_pk": 1,
             "c_varchar": "1",
-            "c_int": 1,
+            "C-Int": 1,
             "c_obj": {
-                "nested_prop1": "value_1",
-                "nested_prop2": "value_2",
-                "nested_prop3": {
-                    "multi_nested_prop1": "multi_value_1",
-                    "multi_nested_prop2": "multi_value_2",
+                "Nested-Prop1": "value_1",
+                "Nested-Prop2": "value_2",
+                "Nested-Prop3": {
+                    "multi_Nested-Prop1": "multi_value_1",
+                    "multi_Nested-Prop2": "multi_value_2",
                 }}}
 
         # NO FLATTENING - No flattening (default)


### PR DESCRIPTION
## Problem

Ran into some crashes because the code would transform the keys in the schema in one way but the keys of the record in another.

## Proposed changes

This PR changes so that keys of records are transformed (lowercased, - replaced with _, etc) just as the schema is.

## Types of changes

What types of changes does your code introduce to target-bigquery?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
