### PR TITLE
add integration tests back

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,5 @@ _Put an `x` in the boxes that apply_
 - [ ] Unit tests for changes (not needed for documentation changes)
 - [ ] CI checks pass with my changes
 - [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
-- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
-- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
 - [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
 - [ ] Relevant documentation is updated including usage instructions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,13 @@ jobs:
         run: make unit_test
 
       # Integration test currently turned off
-#      - name: Integration Tests
-#        env:
-#          LOGGING_CONF_FILE: ./sample_logging.conf
-#        run: make integration_test
+      - name: Integration Tests
+        run: |
+         echo "$GOOGLE_APPLICATION_CREDENTIALS" > service.json
+         export GOOGLE_APPLICATION_CREDENTIALS=service.json
+         export TARGET_BIGQUERY_SCHEMA="`echo "$TARGET_BIGQUERY_SCHEMA" | tr -d "."`"
+         make integration_test
+        env:
+         GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+         TARGET_BIGQUERY_PROJECT: ${{ secrets.TARGET_BIGQUERY_PROJECT }}
+         TARGET_BIGQUERY_SCHEMA: ${{ secrets.TARGET_BIGQUERY_SCHEMA }}${{ matrix.python-version }}


### PR DESCRIPTION
## Problem
Add integration tests to the repo so it's easier to start testing new pull requests

## Proposed changes

Add integration tests to the repo so it's easier to start testing new pull requests


## Types of changes

What types of changes does your code introduce to target-bigquery?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
