### PR TITLE
Cluster table if `key_properties` defined

### DIFF
--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -562,7 +562,7 @@ class DbSync:
     def column_names(self):
         return [safe_column_name(name) for name in self.flatten_schema]
 
-    def create_table(self, is_temporary=False):
+    def create_table(self, is_temporary: bool = False) -> bigquery.Table:
         stream_schema_message = self.stream_schema_message
 
         project_id = self.connection_config['project_id']
@@ -581,8 +581,8 @@ class DbSync:
         if is_temporary:
             table.expires = datetime.datetime.now() + datetime.timedelta(days=1)
 
-        self.client.create_table(table)
-        self.update_clustering_fields(table)
+        table = self.client.create_table(table)
+        return self.update_clustering_fields(table)
 
     def grant_usage_on_schema(self, schema_name, grantee):
         query = "GRANT USAGE ON SCHEMA {} TO GROUP {}".format(schema_name, grantee)
@@ -638,7 +638,7 @@ class DbSync:
     def get_table_columns(self, table: bigquery.Table):
         return {field.name: field for field in table.schema}
 
-    def update_columns(self):
+    def update_columns(self) -> bigquery.Table:
         stream_schema_message = self.stream_schema_message
         stream = stream_schema_message['stream']
         table_name = self.table_name(stream, without_schema=True)
@@ -651,7 +651,7 @@ class DbSync:
             if safe_column_name(name, quotes=False) not in columns
         ]
 
-        self.add_columns(table, columns_to_add)
+        table =self.add_columns(table, columns_to_add)
 
         columns_to_replace = [
             column_type(name, properties_schema)
@@ -661,20 +661,21 @@ class DbSync:
         ]
 
         for field in columns_to_replace:
-            self.version_column(table, field)
+            table = self.version_column(table, field)
 
-        self.update_clustering_fields(table)
+        return self.update_clustering_fields(table)
 
-    def update_clustering_fields(self, table: bigquery.Table) -> None:
+    def update_clustering_fields(self, table: bigquery.Table) -> bigquery.Table:
         new_clustering_fields = [
             self.renamed_columns.get(c, c) for c in primary_column_names(self.stream_schema_message)
         ]
         if table.clustering_fields != new_clustering_fields:
             logger.info('Updating clustering fields: {}'.format(new_clustering_fields))
             table.clustering_fields = new_clustering_fields
-            self.client.update_table(table, ['clustering_fields'])
+            return self.client.update_table(table, ['clustering_fields'])
+        return table
 
-    def version_column(self, table: bigquery.Table, field: bigquery.SchemaField) -> None:
+    def version_column(self, table: bigquery.Table, field: bigquery.SchemaField) -> bigquery.Table:
         column = safe_column_name(field.name, quotes=False)
         col_type_suffixes = {
             'timestamp': 'ti',
@@ -712,16 +713,20 @@ class DbSync:
         # if we didnt find a existing suitable column, create it
         if not column in self.renamed_columns:
             logger.info('Versioning column: {}'.format(field_with_type_suffix))
-            self.add_columns(table, [self.alias_field(field, field_with_type_suffix)])
+            table = self.add_columns(table, [self.alias_field(field, field_with_type_suffix)])
             self.renamed_columns[column] = field_with_type_suffix
+        return table
 
-    def add_columns(self, table: bigquery.Table, fields: List[bigquery.SchemaField]) -> None:
-        schema = table.schema[:]
-        schema.extend(fields)
-        table.schema = schema
+    def add_columns(self, table: bigquery.Table, fields: List[bigquery.SchemaField]) -> bigquery.Table:
+        # Only do an update if there are fields to add.
+        if fields:
+            schema = table.schema
+            schema.extend(fields)
+            table.schema = schema
 
-        logger.info('Adding columns: {}'.format([field.name for field in fields]))
-        self.client.update_table(table, ['schema'])  # API request
+            logger.info('Adding columns: {}'.format([field.name for field in fields]))
+            return self.client.update_table(table, ['schema'])  # API request
+        return table
 
     def sync_table(self):
         stream_schema_message = self.stream_schema_message

--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -578,6 +578,7 @@ class DbSync:
         ]
 
         table = bigquery.Table(table_ref, schema=schema)
+        table.clustering_fields = primary_column_names(self.stream_schema_message)
         if is_temporary:
             table.expires = datetime.datetime.now() + datetime.timedelta(days=1)
 


### PR DESCRIPTION
## Problem

Using unclustered tables makes MERGE statements very expensive in BigQuery as they require full table scans regardless on the data to be merged. DBT has found the same thing: https://github.com/dbt-labs/dbt-core/issues/2196

## Proposed changes

Cluster tables when `key_properties` is defined when creating the table.

This also updates the clustered fields if their schema changes. 


## Types of changes

What types of changes does your code introduce to target-bigquery?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
