### PR TITLE
Fix key error when `time_extracted` is not present in the message

### DIFF
--- a/target_bigquery/stream_utils.py
+++ b/target_bigquery/stream_utils.py
@@ -105,7 +105,7 @@ def add_metadata_values_to_record(record_message):
             return None
 
     extended_record = record_message['record']
-    extended_record['_sdc_extracted_at'] = parse_datetime(record_message.get('time_extracted')) or datetime.now()
+    extended_record['_sdc_extracted_at'] = parse_datetime(record_message.get('time_extracted', datetime.now()))
     extended_record['_sdc_batched_at'] = datetime.now()
     extended_record['_sdc_deleted_at'] = parse_datetime(record_message.get('record', {}).get('_sdc_deleted_at'))
 

--- a/target_bigquery/stream_utils.py
+++ b/target_bigquery/stream_utils.py
@@ -105,7 +105,7 @@ def add_metadata_values_to_record(record_message):
             return None
 
     extended_record = record_message['record']
-    extended_record['_sdc_extracted_at'] = parse_datetime(record_message['time_extracted'])
+    extended_record['_sdc_extracted_at'] = parse_datetime(record_message.get('time_extracted')) or datetime.now()
     extended_record['_sdc_batched_at'] = datetime.now()
     extended_record['_sdc_deleted_at'] = parse_datetime(record_message.get('record', {}).get('_sdc_deleted_at'))
 

--- a/tests/unit/resources/test_stream_utils.py
+++ b/tests/unit/resources/test_stream_utils.py
@@ -1,0 +1,35 @@
+import unittest
+from datetime import datetime
+
+from target_bigquery import stream_utils
+
+class TestStreamUtils(unittest.TestCase):
+    """
+    Unit Tests
+    """
+
+    def test_add_metadata_values_to_record(self):
+        """Test adding metadata"""
+
+        dt = "2017-11-20T16:45:33.000Z"
+        record = { "type": "RECORD", "stream": "foo", "time_extracted": dt, "record": {"id": "2"} }
+        result = stream_utils.add_metadata_values_to_record(record)
+
+        self.assertEqual(result.get("id"), "2")
+        self.assertEqual(result.get("_sdc_extracted_at"), datetime.strptime(dt, '%Y-%m-%dT%H:%M:%S.%fZ'))
+
+        extra_attrs = ['_sdc_batched_at', '_sdc_deleted_at']
+        for attr in extra_attrs:
+            self.assertTrue(attr in result)
+
+    def test_add_metadata_values_to_record_when_no_time_extracted(self):
+        """Test adding metadata when there's no time extracted in the record message """
+
+        record = { "type": "RECORD", "stream": "foo", "record": {"id": "2"} }
+
+        result = stream_utils.add_metadata_values_to_record(record)
+        self.assertEqual(result.get("id"), "2")
+
+        extra_attrs = ['_sdc_extracted_at', '_sdc_batched_at', '_sdc_deleted_at']
+        for attr in extra_attrs:
+            self.assertTrue(attr in result)

--- a/tests/unit/resources/test_stream_utils.py
+++ b/tests/unit/resources/test_stream_utils.py
@@ -27,8 +27,10 @@ class TestStreamUtils(unittest.TestCase):
 
         record = { "type": "RECORD", "stream": "foo", "record": {"id": "2"} }
 
+        dt = datetime.now()
         result = stream_utils.add_metadata_values_to_record(record)
         self.assertEqual(result.get("id"), "2")
+        self.assertGreaterEqual(result.get("_sdc_extracted_at"), dt)
 
         extra_attrs = ['_sdc_extracted_at', '_sdc_batched_at', '_sdc_deleted_at']
         for attr in extra_attrs:


### PR DESCRIPTION
## Problem

Some taps don't add `time_extracted` field, and loading to BQ fails with: 
```
KeyError: 'time_extracted' 
```
https://github.com/singer-io/getting-started/blob/master/docs/SPEC.md#record-message


## Proposed changes

If time_extracted is not provided default to the current time.

## Types of changes

What types of changes does your code introduce to target-bigquery?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
