### PR TITLE
Change Avro Timestamp date-time format to support microseconds

### DIFF
--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -131,7 +131,7 @@ def column_schema_avro(name, schema_property):
     elif property_format == 'date-time':
         result_type = {
             'type': 'long',
-            'logicalType': 'timestamp-millis'}
+            'logicalType': 'timestamp-micros'}
     elif property_format == 'time':
         result_type = {
             'type': 'int',

--- a/tests/integration/test_target_bigquery_stream.py
+++ b/tests/integration/test_target_bigquery_stream.py
@@ -564,7 +564,7 @@ class TestIntegrationSchema(test_utils.TestIntegration):
         # ----------------------------------------------------------------------
         # Check rows in table_two
         # ----------------------------------------------------------------------
-        delete_time = datetime.datetime(2019, 10, 13, 14, 6, 31, 838000, tzinfo=timezone.utc)
+        delete_time = datetime.datetime(2019, 10, 13, 14, 6, 31, 838328, tzinfo=timezone.utc)
         expected_table_two = [
             {'cid': 1, 'cvarchar': "updated row", "_sdc_deleted_at": None},
             {'cid': 2, 'cvarchar': 'updated row', "_sdc_deleted_at": None},


### PR DESCRIPTION
## Problem

**Problem**: Avro timestamp field does not respect microseconds.

**Breakdown**:
We started to notice our Postgres export -> Bigquery jobs were failing with the following error:
`google.api_core.exceptions.BadRequest: 400 Query error: UPDATE/MERGE must match at most one source row for each target row at [1:1]` - as it detects duplicates in the BQ temp table: `exported_table_temp`, which it populates before writing to the target table: `exported_table`.
We narrowed down the issue and it is caused by the timestamp fields which were getting rounded off to the nearest millisecond:
Source (PG DB with microsecond resolution):
`2022-02-25T18:01:37.970345+00:00`
TO:
Destination (BQ exported data with millisecond resolution)
`2022-02-25T18:01:37.970000 UTC`

^Notice how the microseconds are not respected when the data reaches BQ^

When [target-bigquery](https://github.com/transferwise/pipelinewise-target-bigquery) gets the data from a given tap (example: [tap-postgres](https://github.com/transferwise/pipelinewise-tap-postgres)), it allocates the relevant Avro data type to that column.
When it renders a date-time value, it assigns it a [timestamp-millis](https://avro.apache.org/docs/1.8.0/api/java/org/apache/avro/LogicalTypes.TimeMillis.html) value.
This means that we get a timestamp with 3 decimal places after the second (As opposed to 6 with microseconds).

See the problematic target-bigquery code here:
https://github.com/transferwise/pipelinewise-target-bigquery/blob/master/target_bigquery/db_sync.py#L134
I tried changing the [target-bigquery source code](https://github.com/transferwise/pipelinewise-target-bigquery/blob/master/target_bigquery/db_sync.py#L134) to support the [timestamp-micros datatype](https://avro.apache.org/docs/1.8.0/api/java/org/apache/avro/LogicalTypes.TimestampMicros.html) and this successfully wrote the date_time values in microseconds


## Proposed changes

Changing `column_type_avro` date-time mapping from [timestamp-millis](https://avro.apache.org/docs/1.8.0/api/java/org/apache/avro/LogicalTypes.TimeMillis.html) -> [timestamp-micros](https://avro.apache.org/docs/1.8.0/api/java/org/apache/avro/LogicalTypes.TimestampMicros.html) for accurate timestamp mappings and thus preventing duplication.



## Types of changes

What types of changes does your code introduce to target-bigquery?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
