### PR TITLE
change date column type

### DIFF
--- a/target_bigquery/db_sync.py
+++ b/target_bigquery/db_sync.py
@@ -44,14 +44,16 @@ def validate_config(config):
     return errors
 
 
-# pylint: disable=no-else-return,too-many-return-statements
+# pylint: disable=no-else-return,too-many-branches,too-many-return-statements
 def bigquery_type(property_type, property_format):
     # Every date-time JSON value is currently mapped to TIMESTAMP WITHOUT TIME ZONE
     #
     # TODO: Detect if timezone postfix exists in the JSON and find if DATETIME or
     # TIMESTAMP which includes time zone is the better column type
-    if property_format in ['date', 'date-time']:
+    if property_format == 'date-time':
         return 'timestamp'
+    if property_format == 'date':
+        return 'date'
     elif property_format == 'time':
         return 'time'
     elif 'number' in property_type:
@@ -128,10 +130,14 @@ def column_schema_avro(name, schema_property):
         else:
             result_type = 'string'
 
-    elif property_format in ['date', 'date-time']:
+    elif property_format == 'date-time':
         result_type = {
             'type': 'long',
             'logicalType': 'timestamp-micros'}
+    elif property_format == 'date':
+        result_type = {
+            'type': 'int',
+            'logicalType': 'date'}
     elif property_format == 'time':
         result_type = {
             'type': 'int',
@@ -518,6 +524,7 @@ class DbSync:
         column = sql_utils.safe_column_name(field.name, quotes=False)
         col_type_suffixes = {
             'timestamp': 'ti',
+            'date': 'dy',
             'time': 'tm',
             'numeric': 'de',
             'string': 'st',

--- a/target_bigquery/stream_utils.py
+++ b/target_bigquery/stream_utils.py
@@ -54,6 +54,8 @@ def adjust_timestamps_in_record(record: Dict, schema: Dict) -> None:
         try:
             if _format == 'time':
                 record[key] = parser.parse(record[key]).time()
+            elif _format == 'date':
+                record[key] = parser.parse(record[key]).date()
             else:
                 record[key] = parser.parse(record[key])
         except ParserError:

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -97,7 +97,7 @@ class TestDBSync(unittest.TestCase):
         # Mapping from JSON schema types ot BigQuery column types
         self.assertEqual(mapper(json_str), ('string', 'NULLABLE'))
         self.assertEqual(mapper(json_str_or_null), ('string', 'NULLABLE'))
-        self.assertEqual(mapper(json_date), ('timestamp', 'NULLABLE'))
+        self.assertEqual(mapper(json_date), ('date', 'NULLABLE'))
         self.assertEqual(mapper(json_dt), ('timestamp', 'NULLABLE'))
         self.assertEqual(mapper(json_dt_or_null), ('timestamp', 'NULLABLE'))
         self.assertEqual(mapper(json_t), ('time', 'NULLABLE'))

--- a/tests/unit/test_target_bigquery.py
+++ b/tests/unit/test_target_bigquery.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import itertools
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 from unittest.mock import patch
 
 import target_bigquery
@@ -75,7 +75,7 @@ class TestTargetBigQuery(unittest.TestCase):
 
         self.assertDictEqual({
             'key1': '1',
-            'key2':  datetime(2030, 1, 22, 0, 0),
+            'key2': date(2030, 1, 22),
             'key3': datetime(9999, 12, 31, 23, 59, 59, 999999),
             'key4': timedelta(693595, 86399, 999999),
             'key5': 'I\'m good',


### PR DESCRIPTION
## Problem

Make dates received from the tap as a date format be loaded as dates in BigQuery. Currently they appear as timestamps



## Types of changes

What types of changes does your code introduce to target-bigquery?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
